### PR TITLE
reaplace includedirs with sysincludedirs

### DIFF
--- a/qt.lua
+++ b/qt.lua
@@ -140,7 +140,7 @@ function premake.extensions.qt.customBakeConfig(base, wks, prj, buildcfg, platfo
 	config.qtbinpath		= qtbin
 
 	-- add the includes and libraries directories
-	table.insert(config.includedirs, qtinclude)
+	table.insert(config.sysincludedirs, qtinclude)
 	table.insert(config.libdirs, qtlib)
 
 	-- add the modules
@@ -154,7 +154,7 @@ function premake.extensions.qt.customBakeConfig(base, wks, prj, buildcfg, platfo
 			local libname	= prefix .. module.name .. suffix
 
 			-- configure the module
-			table.insert(config.includedirs, qtinclude .. "/" .. module.include)
+			table.insert(config.sysincludedirs, qtinclude .. "/" .. module.include)
 			table.insert(config.links, libname)
 			if module.defines ~= nil then
 				qt.mergeDefines(config, module.defines)


### PR DESCRIPTION
I think Qt should be included with -isystem  instead of -I 