### PR TITLE
Fix the default Qt Path case.

### DIFF
--- a/qt.lua
+++ b/qt.lua
@@ -16,7 +16,7 @@ premake.extensions.qt = {
 	-- these are private, do not touch
 	--
 	enabled = false,
-	defaultPath = os.getenv("QTDIR") or os.getenv("QT_DIR")
+	defaultpath = os.getenv("QTDIR") or os.getenv("QT_DIR")
 }
 
 --


### PR DESCRIPTION
I noticed that the default path usecase (set from QTDIR or QT_DIR environment variables) got broken with commit 85e6f94. 