### PR TITLE
Don't run MOC on Q_OBJECT_FAKE or comments

### DIFF
--- a/qt.lua
+++ b/qt.lua
@@ -452,7 +452,7 @@ function premake.extensions.qt.needMOC(filename)
 
 		-- scan it to find 'Q_OBJECT' or 'Q_GADGET'
 		for line in file:lines() do
-			if line:find("Q_OBJECT") or line:find("Q_GADGET") then
+			if line:find("^%s*Q_OBJECT%f[^%w_]") or line:find("^%s*Q_GADGET%f[^%w_]") then
 				needmoc = true
 				break
 			end


### PR DESCRIPTION
This patch is to prevent false positive matches of Q_OBJECT and Q_GADGET. This is so it can support stuff like Q_OBJECT_FAKE and the ability to comment out Q_OBJECT lines.

Q_OBJECT_FAKE is an undocumented feature used by Qt in its COM binding (among other things). Basically it's equivalent to the Q_OBJECT macro but without the *_moc.cpp file generation for that class.