### PR TITLE
Add support for including private Qt headers

### DIFF
--- a/_preload.lua
+++ b/_preload.lua
@@ -111,6 +111,18 @@ premake.api.register {
 }
 
 --
+-- Specify the version of Qt.
+-- This is used to determine the private header path when adding private modules.
+-- If unspecified, the addon will scan `qtincludepath .. "/QtCore/qconfig.h"` and `qglobal.h`
+-- for the version string.
+--
+premake.api.register {
+	name = "qtversion",
+	scope = "config",
+	kind = "string"
+}
+
+--
 -- Private use only : used by the addon to know if qt has already been enabled or not
 --
 premake.api.register {


### PR DESCRIPTION
This mirrors QMake's `QT += *-private` functionality.

Essentially this will implicitly add the corresponding public module in addition to adding its private header paths to the list of includes.

These paths take the form of `includepath/Module/version` and `includepath/Module/version/Module`

When including a private module; it will attempt to retrieve the version string (if not explicitly stated in the project via config.qtversion) by querying qconfig.h and qglobal.h (since the Qt devs moved the version string starting with 5.6).