### PR TITLE
Fix error case when there is no explicit or default path set

### DIFF
--- a/qt.lua
+++ b/qt.lua
@@ -53,9 +53,9 @@ function premake.extensions.qt.getPaths(cfg)
 	local qtpath = cfg.qtpath or premake.extensions.qt.defaultpath
 
 	-- return the paths
-	return cfg.qtincludepath or qtpath .. "/include",
-		   cfg.qtlibpath or qtpath .. "/lib",
-		   cfg.qtbinpath or qtpath .. "/bin"
+	return cfg.qtincludepath or (qtpath and qtpath .. "/include"),
+		   cfg.qtlibpath or (qtpath and qtpath .. "/lib"),
+		   cfg.qtbinpath or (qtpath and qtpath .. "/bin")
 end
 
 --


### PR DESCRIPTION
I noticed that when qtpath is nil, the concat will fail in getPaths().

This patch should make the more helpful error message get emitted :)