### PR TITLE
Under linux set an rpath to the Qt lib dir and enable ld optimisation.

### DIFF
--- a/qt.lua
+++ b/qt.lua
@@ -186,6 +186,11 @@ function premake.extensions.qt.customBakeConfig(base, wks, prj, buildcfg, platfo
 	table.insert(config.includedirs, qtinclude)
 	table.insert(config.libdirs, qtlib)
 
+	if _OS == "linux" then
+		table.insert(config.linkoptions, "-Wl,-rpath," .. qtlib)
+		table.insert(config.linkoptions, "-Wl,-O1")
+	end
+  
 	-- add the modules
 	for _, modulename in ipairs(config.qtmodules) do
 


### PR DESCRIPTION
I'm seeing linker errors under GCC and Clang unless I set an explicit rpath to the Qt lib directory.

Looking at the Makefile generated by qmake, it looks like it adds an rpath (and optimisation flag) to the linker options. So I don't think it's a problem to replicate that here.

I think you'll only hit the linker issue when a Qt library implicitly links against another that isn't in the project's link list (eg. libicui18n referenced from libQt5Core).