### PR TITLE
Update path APIs to resolve tokens

### DIFF
--- a/_preload.lua
+++ b/_preload.lua
@@ -11,7 +11,8 @@ premake.extensions.qt = true
 premake.api.register {
 	name = "qtpath",
 	scope = "config",
-	kind = "path"
+	kind = "path",
+	tokens = true
 }
 
 --
@@ -21,7 +22,8 @@ premake.api.register {
 premake.api.register {
 	name = "qtbinpath",
 	scope = "config",
-	kind = "path"
+	kind = "path",
+	tokens = true
 }
 
 --
@@ -31,7 +33,8 @@ premake.api.register {
 premake.api.register {
 	name = "qtincludepath",
 	scope = "config",
-	kind = "path"
+	kind = "path",
+	tokens = true
 }
 
 --
@@ -41,7 +44,8 @@ premake.api.register {
 premake.api.register {
 	name = "qtlibpath",
 	scope = "config",
-	kind = "path"
+	kind = "path",
+	tokens = true
 }
 
 --
@@ -89,7 +93,8 @@ premake.api.register {
 premake.api.register {
 	name = "qtgenerateddir",
 	scope = "config",
-	kind = "path"
+	kind = "path",
+	tokens = true
 }
 
 --


### PR DESCRIPTION
This change allows qtpath, qtbinpath, et al, to include tokens which can be useful in cases where the Premake context is important in determining those paths.

For example, the Qt SDK Installer installs each platform SDK to, say, `<qt-install-dir>/<qt-version>/msvc2019_64`. The information contained in premake's cfg object can be used to determine that at bake time, but it must be resolved as a token:

    qtpath '%{getQtSdkDir(cfg)}'

Where `getQtSdkDir(cfg)` is a function in the global scope that can translate the context into the correct Qt SDK path.

While one could set QTDIR before running premake, this doesn't behave well with multi-arch Visual Studio workspaces, or when a custom build of the Qt SDK places shared/static runtime and debug/release builds into separate paths.