### PR TITLE
`fcfg.buildinputs` should only have extra input file.

### DIFF
--- a/qt.lua
+++ b/qt.lua
@@ -470,8 +470,6 @@ function premake.extensions.qt.addUICustomBuildRule(fcfg, cfg)
 	fcfg.buildmessage	= "Uic'ing " .. fcfg.name
 	fcfg.buildcommands	= { command }
 	fcfg.buildoutputs	= { output }
-	fcfg.buildinputs	= { fcfg.abspath }
-
 end
 
 --


### PR DESCRIPTION
Before that change,
generated files have 2 same dependencies.