### PR TITLE
Allow to insert qt includes as external/system include.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -72,6 +72,13 @@ Set the path for the Qt headers. If this is not used, the addon will set the
 includepath to the `include` child folder of the one set by `qtpath`, or one of the
 environment variable.
 
+##### qtuseexternalinclude (boolean)
+
+By default, Qt modules' include directories are added as regular include directories,
+meaning they might issue warnings.
+You can use this option so that the include directories are instead added as "external" ones
+so that compilers supporting this won't ever issue any warnings on those includes.
+
 ##### qtlibpath "path"
 
 Set the path for the Qt libraries. If this is not used, the addon will set the
@@ -198,6 +205,11 @@ solution "TestQt"
 		-- Enable Qt for this project.
 		--
 		qt.enable()
+
+		--
+		-- Include Qt module directories as external to avoid possible warnings.
+		--
+		qtuseexternalinclude ( true )
 
 		--
 		-- Setup the Qt path. This apply to the current configuration, so

--- a/_preload.lua
+++ b/_preload.lua
@@ -16,6 +16,17 @@ premake.api.register {
 }
 
 --
+-- By default, Qt modules' include directories are added as regular include directories,
+-- meaning they might issue warnings.
+-- You can use this option so that the include directories are instead added as "external" ones
+-- so that compilers supporting this won't ever issue any warnings on those includes.
+premake.api.register {
+	name = "qtuseexternalinclude",
+	scope = "config",
+	kind = "boolean"
+}
+
+--
 -- Set the binary path. By default, its `qtpath .. "/bin"`. Use
 -- this command to override it.
 --

--- a/qt.lua
+++ b/qt.lua
@@ -204,7 +204,7 @@ function premake.extensions.qt.customBakeConfig(base, wks, prj, buildcfg, platfo
 	config.qtbinpath		= qtbin
 
 	-- add the includes and libraries directories
-	table.insert(config.includedirs, qtinclude)
+	table.insert(iif(config.qtuseexternalinclude, config.externalincludedirs, config.includedirs), qtinclude)
 	table.insert(config.libdirs, qtlib)
 
 	-- get the prefix and suffix
@@ -264,8 +264,10 @@ function premake.extensions.qt.customBakeConfig(base, wks, prj, buildcfg, platfo
 			local module = modules[modulename]
 			if module ~= nil then
 				local privatepath = path.join(qt.getIncludeDir(config, module), config.qtversion)
-				table.insert(config.includedirs, privatepath)
-				table.insert(config.includedirs, path.join(privatepath , module.include))
+
+				includedirs = iif(config.qtuseexternalinclude, config.externalincludedirs, config.includedirs)
+				table.insert(includedirs, privatepath)
+				table.insert(includedirs, path.join(privatepath , module.include))
 			end
 
 		end
@@ -277,7 +279,8 @@ function premake.extensions.qt.customBakeConfig(base, wks, prj, buildcfg, platfo
 			local libname	= prefix .. module.name .. suffix
 
 			-- configure the module
-			table.insert(config.includedirs, qt.getIncludeDir(config, module))
+			table.insert(iif(config.qtuseexternalinclude, config.externalincludedirs, config.includedirs), qt.getIncludeDir(config, module))
+
 			if _TARGET_OS == "macosx" then
 				table.insert(config.links, path.join(qtlib, module.include .. ".framework"))
 			else


### PR DESCRIPTION
Similar to https://github.com/dcourtois/premake-qt/pull/4
Notice that premake has renamed `sysincludedirs` into `externalincludedirs` since above PR. (from gcc-like name to msvc one).

As you ask an option, I add one (not sure about the name though)

Qt headers might (and currently does) generate warnings.
marked them as system/external header allows to ignore those warnings.

