### PR TITLE
Add options to handle Qt translation tool

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -152,6 +152,16 @@ in double quotes, e.g. `qtuicargs { "foo", "bar" }` will appear as `"foo" "bar"`
 An optional list of arguments that will be sent to the Qt rcc tool. Each argument will be encased
 in double quotes, e.g. `qtrccargs { "foo", "bar" }` will appear as `"foo" "bar"` in the command line.
 
+##### qtlreleaseargs { "arg", "arg", ... }
+
+An optional list of arguments that will be sent to the Qt lrelease tool. Each argument will be encased
+in double quotes, e.g. `qtlreleaseargs { "foo", "bar" }` will appear as `"foo" "bar"` in the command line.
+
+##### qtqmgenerateddir "path"
+
+The optional path, relative to the current script, where the qm files generated
+by Qt will be created. If omitted, the default behavior is to generate those files in the target directory.
+
 ##### qtcommandlinesizelimit ( integer )
 
 This option can be used to tell Qt tools to store their command line arguments
@@ -198,7 +208,7 @@ solution "TestQt"
 		--
 
 		-- add the files
-		files { "**.h", "**.cpp", "**.ui" "**.qrc" }
+		files { "**.h", "**.cpp", "**.ts", "**.ui", "**.qrc" }
 
 
 		--

--- a/_preload.lua
+++ b/_preload.lua
@@ -126,6 +126,27 @@ premake.api.register {
 }
 
 --
+-- Specify a list of custom options to send to the Qt lrelease command line.
+--
+premake.api.register {
+	name = "qtlreleaseargs",
+	scope = "config",
+	kind = "string-list"
+}
+
+--
+-- Specify the path, relative to the current script, where the qm files generated
+-- by Qt will be created. If this command is not used, the default behavior
+-- is to generate those files in the target directory.
+--
+premake.api.register {
+	name = "qtqmgenerateddir",
+	scope = "config",
+	kind = "path",
+	tokens = true
+}
+
+--
 -- Specify a list of custom options to send to the Qt uic command line.
 --
 premake.api.register {


### PR DESCRIPTION
i.e conversion of .ts -> .qm

No rules added to update ts files themselves (regeneration would be needed for almost any file changes (files containing `tr(..)`, .ui files...).
Anyway, translators won't have add anything ;)

Tested on my premake testing repo https://github.com/Jarod42/premake-sample-projects/tree/qt_translate

As usual doesn't works with gmake2.