### PR TITLE
Make path api variable be pathVars

### DIFF
--- a/_preload.lua
+++ b/_preload.lua
@@ -113,7 +113,8 @@ premake.api.register {
 	name = "qtgenerateddir",
 	scope = "config",
 	kind = "path",
-	tokens = true
+	tokens = true,
+	pathVars = true
 }
 
 --
@@ -143,7 +144,8 @@ premake.api.register {
 	name = "qtqmgenerateddir",
 	scope = "config",
 	kind = "path",
-	tokens = true
+	tokens = true,
+	pathVars = true
 }
 
 --


### PR DESCRIPTION
Make path api variables be pathVars (with tokens replacement, '%{cfg.objdir}' becomes '$(OBJDIR)' in makefile instead of harcoded path for example).

That might allow, for Code::Blocks which doesn't support per-file configuration different by configuration, to have its token and so identical build command string (even if they substitute differently per configuration).